### PR TITLE
fix(PHPUnit): new key server

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,7 +51,7 @@
   with_items:
     - 'wget https://phar.phpunit.de/phpunit.phar'
     - 'wget https://phar.phpunit.de/phpunit.phar.asc'
-    - 'gpg --keyserver keyserver.ubuntu.com --recv-keys 0x4AA394086372C20A'
+    - 'gpg --keyserver pgp.uni-mainz.de --recv-keys 0x4AA394086372C20A'
     - 'gpg phpunit.phar.asc'
     - 'mv phpunit.phar /usr/local/bin/phpunit'
     - 'rm phpunit.phar.asc'


### PR DESCRIPTION
Trying to address this problem:

`TASK [telusdigital.php : PHPUnit | Download and Install] ***********************
failed: [default] (item=gpg phpunit.phar.asc) => {"changed": true, "cmd": "gpg phpunit.phar.asc", "delta": "0:00:00.048734", "end": "2018-06-13 21:49:42.067908", "item": "gpg phpunit.phar.asc", "msg": "non-zero return code", "rc": 1, "start": "2018-06-13 21:49:42.019174", "stderr": "gpg: Signature made Sun 17 Dec 2017 06:31:44 AM UTC using RSA key ID 6372C20A\ngpg: BAD signature from \"Sebastian Bergmann <sb@sebastian-bergmann.de>\"", "stderr_lines":["gpg: Signature made Sun 17 Dec 2017 06:31:44 AM UTC using RSA key ID 6372C20A", "gpg: BAD signature from \"Sebastian Bergmann <sb@sebastian-bergmann.de>\""], "stdout": "", "stdout_lines": []}`